### PR TITLE
Add AgentInterface and AtkUnitBase inheritance support

### DIFF
--- a/XivReClassPlugin/Game/AgentModule.cs
+++ b/XivReClassPlugin/Game/AgentModule.cs
@@ -58,10 +58,13 @@ public class AgentInterface : IEquatable<AgentInterface>, IComparable<AgentInter
 		node.AddressFormula = $"<Agent({AgentId})>";
 		node.Name = $"Client::UI::Agent::Agent{AgentId}";
 
-		if (!string.IsNullOrWhiteSpace(Name) && AgentModule.AgentList.Count(a => a.Name.Equals(Name)) == 1) {
+		if ((!string.IsNullOrWhiteSpace(Name) && AgentModule.AgentList.Count(a => a.Name.Equals(Name)) == 1) {
 			node.AddressFormula = $"<Agent({Name})>";
 			node.Name = $"Client::UI::Agent::{Name}";
 		}
+
+		if (!string.IsNullOrEmpty(ClassName))
+			node.Name = ClassName;
 
 		var agentInterfaceNode = Program.MainForm.CurrentProject.Classes.FirstOrDefault(node => node.Name.Equals("Client::UI::Agent::AgentInterface"));
 		if (agentInterfaceNode != null) {

--- a/XivReClassPlugin/Game/AgentModule.cs
+++ b/XivReClassPlugin/Game/AgentModule.cs
@@ -53,16 +53,28 @@ public class AgentInterface : IEquatable<AgentInterface>, IComparable<AgentInter
 	public ClassNode? CreateClassNode() {
 		if (Program.MainForm.CurrentProject.Classes.Any(c => c.Name.Equals(Name)))
 			return null;
+
 		var node = ClassNode.Create();
 		node.AddressFormula = $"<Agent({AgentId})>";
-		node.Name = $"Agent{AgentId}";
-		if (!string.IsNullOrWhiteSpace(Name)) {
-			if (AgentModule.AgentList.Count(a => a.Name.Equals(Name)) == 1) {
-				node.AddressFormula = $"<Agent({Name})>";
-				node.Name = Name;
-			}
+		node.Name = $"Client::UI::Agent::Agent{AgentId}";
+
+		if (!string.IsNullOrWhiteSpace(Name) && AgentModule.AgentList.Count(a => a.Name.Equals(Name)) == 1) {
+			node.AddressFormula = $"<Agent({Name})>";
+			node.Name = $"Client::UI::Agent::{Name}";
 		}
-		node.AddBytes(Math.Max(0x30, Size));
+
+		var agentInterfaceNode = Program.MainForm.CurrentProject.Classes.FirstOrDefault(node => node.Name.Equals("Client::UI::Agent::AgentInterface"));
+		if (agentInterfaceNode != null) {
+			var instanceNode = new ClassInstanceNode();
+			instanceNode.ChangeInnerNode(agentInterfaceNode);
+			instanceNode.Name = "AgentInterface";
+			node.AddNode(instanceNode);
+			if (Size - 0x28 > 0)
+				node.AddBytes(Size - 0x28);
+		} else {
+			node.AddBytes(Math.Max(0x28, Size));
+		}
+
 		return node;
 	}
 

--- a/XivReClassPlugin/Game/AtkUnitManager.cs
+++ b/XivReClassPlugin/Game/AtkUnitManager.cs
@@ -45,34 +45,47 @@ public unsafe class Addon {
 	public ulong Address { get; }
 	public string Name { get; }
 	public int Size { get; }
-    public ulong VTableOffset { get; }
-    public string ClassName { get; }
+	public ulong VTableOffset { get; }
+	public string ClassName { get; }
 
 	public Addon(nint address, AtkUnitBase unitBase) {
 		Address = (ulong)address;
 		UnitBase = unitBase;
 
-        Name = Encoding.UTF8.GetString(unitBase.Name, 0x20);
-        var idx = Name.IndexOf('\0');
-        if (idx != -1)
-            Name = Name.Remove(idx);
+		Name = Encoding.UTF8.GetString(unitBase.Name, 0x20);
+		var idx = Name.IndexOf('\0');
+		if (idx != -1)
+			Name = Name.Remove(idx);
 
-        var vtable = Ffxiv.Memory.Read<nint>(address);
-        VTableOffset = (ulong)Ffxiv.Memory.GetMainModuleOffset(vtable);
-        ClassName = Ffxiv.Symbols.TryGetClassName(vtable, out var className, true) ? className : string.Empty;
+		var vtable = Ffxiv.Memory.Read<nint>(address);
+		VTableOffset = (ulong)Ffxiv.Memory.GetMainModuleOffset(vtable);
+		ClassName = Ffxiv.Symbols.TryGetClassName(vtable, out var className, true) ? className : string.Empty;
 
-        Size = Ffxiv.Memory.TryGetSizeFromFunction(Ffxiv.Memory.Read<nint>(vtable + 0 * 8));
+		Size = Ffxiv.Memory.TryGetSizeFromFunction(Ffxiv.Memory.Read<nint>(vtable + 0 * 8));
 	}
 
-    public ClassNode? CreateClassNode() {
-        if (Program.MainForm.CurrentProject.Classes.Any(c => c.Name.Equals(Name)))
-            return null;
-        var node = ClassNode.Create();
-        node.AddressFormula = $"<Addon({Name})>";
-        node.Name = $"Addon{Name}";
-        node.AddBytes(Math.Max(0x220, Size));
-        return node;
-    }
+	public ClassNode? CreateClassNode() {
+		if (Program.MainForm.CurrentProject.Classes.Any(c => c.Name.Equals(Name)))
+			return null;
+
+		var node = ClassNode.Create();
+		node.AddressFormula = $"<Addon({Name})>";
+		node.Name = $"Client::UI::Addon{Name}";
+
+		var atkUnitBaseNode = Program.MainForm.CurrentProject.Classes.FirstOrDefault(node => node.Name.Equals("Component::GUI::AtkUnitBase"));
+		if (atkUnitBaseNode != null) {
+			var instanceNode = new ClassInstanceNode();
+			instanceNode.ChangeInnerNode(atkUnitBaseNode);
+			instanceNode.Name = "AtkUnitBase";
+			node.AddNode(instanceNode);
+			if (Size - 0x230 > 0)
+				node.AddBytes(Size - 0x230);
+		} else {
+			node.AddBytes(Math.Max(0x230, Size));
+		}
+
+		return node;
+	}
 }
 
 [StructLayout(LayoutKind.Explicit, Size = 0x810)]
@@ -84,7 +97,7 @@ public unsafe struct AtkUnitList {
 	[FieldOffset(0x808)] public ushort Length;
 }
 
-[StructLayout(LayoutKind.Explicit, Size = 0x220)]
+[StructLayout(LayoutKind.Explicit, Size = 0x230)]
 public unsafe struct AtkUnitBase {
 	[FieldOffset(0x00)] public nint VFTable;
 	[FieldOffset(0x08)] public fixed byte Name[0x20];

--- a/XivReClassPlugin/Game/AtkUnitManager.cs
+++ b/XivReClassPlugin/Game/AtkUnitManager.cs
@@ -70,7 +70,7 @@ public unsafe class Addon {
 
 		var node = ClassNode.Create();
 		node.AddressFormula = $"<Addon({Name})>";
-		node.Name = $"Client::UI::Addon{Name}";
+		node.Name = !string.IsNullOrEmpty(ClassName) ? ClassName : $"Client::UI::Addon{Name}";
 
 		var atkUnitBaseNode = Program.MainForm.CurrentProject.Classes.FirstOrDefault(node => node.Name.Equals("Component::GUI::AtkUnitBase"));
 		if (atkUnitBaseNode != null) {


### PR DESCRIPTION
When creating an agent or addon from one of the lists provided in the FFXIV menu, it will search for the base class and add it as class instance node.

For agents, the class needs to be named `Client::UI::Agent::AgentInterface`.

![Agent Preview](https://github.com/user-attachments/assets/6e4f6e6a-8ce1-4568-afe9-0f9311565ddd)

For addons, the class needs to be named `Component::GUI::AtkUnitBase`.

![Addon Preview](https://github.com/user-attachments/assets/7cee4f8f-f8bc-4467-90be-0c05c79ddbfe)

It also adds the namespace as prefix to the class name now, but will always prefer to use ClassName if present.